### PR TITLE
feat: add cron job config and dummy route

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-issue.md
+++ b/.github/ISSUE_TEMPLATE/new-issue.md
@@ -1,10 +1,9 @@
 ---
 name: New Issue
 about: Create a new issue
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
 **Description**
@@ -14,6 +13,7 @@ A clear and concise description of what the problem is. Ex. I'm always frustrate
 A clear and concise description of what you want to happen.
 
 Steps:
+
 - step 1
 - step 2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,6 @@ jobs:
           # - Settings -> Secrets and variables -> New repository secret
           MONGO_URI: ${{ secrets.MONGO_URI }}
           # Add additional environment variables here
-      
+
       - name: Run tests
         run: npm test

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/src/app/api/egrid/route.ts
+++ b/src/app/api/egrid/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Route to fetch the egrid data
+ * TODO: Implement the route
+ * TODO: Add authorization to restrict access to scheduled cron job
+ */
+export async function POST() {
+  return NextResponse.json({ message: "Hello from the egrid API!" });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/egrid",
+      "schedule": "0 17 * * 5"
+    }
+  ]
+}


### PR DESCRIPTION
## Developer: Ryan Chan

Closes N/A

### Pull Request Summary

Setting up cron job to run once per week (Friday at 9am PST) on the data fetcher, currently implemented as a dummy api

### Modifications

- `vercel.json`: cron job configuration
- `/api/egrid/route.ts`: dummy route for data fetcher

The rest are linting fixes

### Testing Considerations

We can only test to see if the scheduler is set up properly in a production environment
But Vercel has a [cron expression validator](https://vercel.com/docs/cron-jobs#cron-expressions) to test expressions against

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

N/A
