### PR TITLE
fix: changed formula dependency validation to allow for input variabl…

### DIFF
--- a/src/utils/formula-parser.ts
+++ b/src/utils/formula-parser.ts
@@ -37,8 +37,9 @@ export class FormulaParser<T extends Record<string, number>> {
   }
 
   private validateFormulaDependencies(): boolean {
+    const inputVariables = this.getAllVariables();
     return Array.from(this.formulas.values()).every((formula) =>
-      formula.dependencies.every((dependency) => this.formulas.has(dependency)),
+      formula.dependencies.every((dependency) => this.formulas.has(dependency) || inputVariables.has(dependency)),
     );
   }
 
@@ -109,6 +110,12 @@ export class FormulaParser<T extends Record<string, number>> {
 
     // update adjacency list and in-degrees
     formula.dependencies.forEach((dependency) => {
+      // at this point, getAllVariables only includes the input variables, as we don't add formulas as variables until evaluation
+      // If the dependency is an input variable, don't include it in our adjacency graph
+      if (this.getAllVariables().has(dependency)) {
+        return;
+      }
+
       if (!this.formulaAdj.has(dependency)) {
         this.formulaAdj.set(dependency, []);
       }

--- a/test/mocks/formula-mocks.ts
+++ b/test/mocks/formula-mocks.ts
@@ -19,14 +19,14 @@ export const MOCK_FORMULAS = [
     name: "Test formula 2",
     expression: "a * b + c",
     setupScope: jest.fn(),
-    dependencies: [],
+    dependencies: ["a", "b", "c"],
   },
   {
     id: "formula_3",
     name: "Test formula 3",
     expression: "a + b",
     setupScope: jest.fn(),
-    dependencies: [],
+    dependencies: ["a", "b"],
   },
 ] as unknown as Formula[];
 
@@ -44,7 +44,7 @@ export const MOCK_FORMULAS_EXTENDED = [
     name: "Test formula 5",
     expression: "formula_2 * formula_3",
     setupScope: jest.fn(),
-    dependencies: [],
+    dependencies: ["formula_2", "formula_3"],
   },
 ] as unknown as Formula[];
 
@@ -77,13 +77,13 @@ export const MOCK_FORMULAS_WITH_CYCLE = [
     name: "Test formula 1",
     expression: "a + b",
     setupScope: jest.fn(),
-    dependencies: ["formula_2"],
+    dependencies: ["formula_2", "a", "b"],
   },
   {
     id: "formula_2",
     name: "Test formula 2",
     expression: "a * b + c",
     setupScope: jest.fn(),
-    dependencies: ["formula_1"],
+    dependencies: ["formula_1", "a", "b", "c"],
   },
 ] as unknown as Formula[];


### PR DESCRIPTION
## Developer: Shayan Daijavad

Closes #40 

### Pull Request Summary

Changed validateFormulaDependencies in formula-parser.ts to allow for inputVariables to be included as dependencies in a formula.

### Modifications

src/utils/formula-parser.ts: validateFormulaDependencies now checks input variables
test/mocks/formula-mocks.ts now includes input variables in each formula's dependencies


### Testing Considerations

I added the input variables to the dependencies of the existing formulas that are being tested

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

