### PR TITLE
69 separate egrid and avert location enums

### DIFF
--- a/src/components/ui/calculator-form.tsx
+++ b/src/components/ui/calculator-form.tsx
@@ -8,10 +8,10 @@ import { Input } from "@/components/ui/input";
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { CalculateInput } from "@/schema/api";
-import { Location, PowerPlantClass } from "@/schema/egrid";
+import { EgridLocation, PowerPlantClass } from "@/schema/egrid";
 
 const powerPlantOptions = PowerPlantClass.options;
-const locationOptions = Location.options;
+const locationOptions = EgridLocation.options;
 
 export default function CalculatorForm() {
   const form = useForm({

--- a/src/database/avert-model.ts
+++ b/src/database/avert-model.ts
@@ -1,10 +1,10 @@
 import mongoose, { Schema } from "mongoose";
-import { PowerPlantClass, Location } from "@/schema/egrid";
+import { PowerPlantClass, EgridLocation } from "@/schema/egrid";
 
 export const AvertSchema = new Schema(
   {
     year: { type: Number, required: true },
-    location: { type: String, enum: Location.options, required: true }, //US, subregion, or state
+    location: { type: String, enum: EgridLocation.options, required: true }, //US, subregion, or state
     powerPlantClass: { type: String, enum: PowerPlantClass.options, required: true },
     avoidedCo2EmissionRateLbMwh: { type: Number }, //pound per megawatt hour
     avoidedNoxEmissionRateLbMwh: { type: Number }, //pound per megawatt hour

--- a/src/database/avert-model.ts
+++ b/src/database/avert-model.ts
@@ -1,10 +1,11 @@
 import mongoose, { Schema } from "mongoose";
-import { PowerPlantClass, EgridLocation } from "@/schema/egrid";
+import { PowerPlantClass } from "@/schema/egrid";
+import { AvertLocation } from "@/schema/avert";
 
 export const AvertSchema = new Schema(
   {
     year: { type: Number, required: true },
-    location: { type: String, enum: EgridLocation.options, required: true }, //US, subregion, or state
+    location: { type: String, enum: AvertLocation.options, required: true },
     powerPlantClass: { type: String, enum: PowerPlantClass.options, required: true },
     avoidedCo2EmissionRateLbMwh: { type: Number }, //pound per megawatt hour
     avoidedNoxEmissionRateLbMwh: { type: Number }, //pound per megawatt hour

--- a/src/database/egrid-model.ts
+++ b/src/database/egrid-model.ts
@@ -1,10 +1,10 @@
 import mongoose, { Schema } from "mongoose";
-import { EgridRecord, Location } from "@/schema/egrid";
+import { EgridRecord, EgridLocation } from "@/schema/egrid";
 
 const EgridSchema = new Schema<EgridRecord>(
   {
     year: { type: Number, required: true },
-    location: { type: String, enum: Location.options, required: true }, //US, subregion, or state
+    location: { type: String, enum: EgridLocation.options, required: true }, //US, subregion, or state
     nameplateCapacityMw: { type: Number }, //megawatts
     annualHeatInputMmbtu: { type: Number }, //metric million British thermal units
     ozoneSeasonHeatInputMmbtu: { type: Number }, //metric million British thermal units

--- a/src/schema/api.ts
+++ b/src/schema/api.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
-import { PowerPlantClass, Location } from "@/schema/egrid";
+import { PowerPlantClass, EgridLocation } from "@/schema/egrid";
 
 export const CalculateInput = z.object({
   installedCapacity: z.number(),
   powerPlantClass: PowerPlantClass,
-  location: Location,
+  location: EgridLocation,
   capacityFactor: z.number(),
   population2070: z.number(),
   startYear: z.number(),

--- a/src/schema/avert.ts
+++ b/src/schema/avert.ts
@@ -1,9 +1,33 @@
 import { z } from "zod";
-import { PowerPlantClass, EgridLocation } from "@/schema/egrid";
+import { PowerPlantClass } from "@/schema/egrid";
+
+/**
+ * eGRID country, subregion, and state codes
+ */
+export const AvertLocation = z.enum([
+  // Country
+  "US",
+  // Regions
+  "California",
+  "Carolinas",
+  "Central",
+  "Florida",
+  "Mid-Atlantic",
+  "Midwest",
+  "New England",
+  "New York",
+  "Northwest",
+  "Rocky Mountains",
+  "Southeast",
+  "Southwest",
+  "Tennessee",
+  "Texas",
+]);
+export type AvertLocation = z.infer<typeof AvertLocation>;
 
 export const AvertRecordKey = z.object({
   year: z.number().int().min(2000).max(2100),
-  location: EgridLocation,
+  location: AvertLocation,
   powerPlantClass: PowerPlantClass,
 });
 

--- a/src/schema/avert.ts
+++ b/src/schema/avert.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { PowerPlantClass } from "@/schema/egrid";
 
 /**
- * eGRID country, subregion, and state codes
+ * AVERT country, region
  */
 export const AvertLocation = z.enum([
   // Country

--- a/src/schema/avert.ts
+++ b/src/schema/avert.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
-import { PowerPlantClass, Location } from "@/schema/egrid";
+import { PowerPlantClass, EgridLocation } from "@/schema/egrid";
 
 export const AvertRecordKey = z.object({
   year: z.number().int().min(2000).max(2100),
-  location: Location,
+  location: EgridLocation,
   powerPlantClass: PowerPlantClass,
 });
 

--- a/src/schema/egrid.ts
+++ b/src/schema/egrid.ts
@@ -16,7 +16,7 @@ export type PowerPlantClass = z.infer<typeof PowerPlantClass>;
 /**
  * eGRID country, subregion, and state codes
  */
-export const Location = z.enum([
+export const EgridLocation = z.enum([
   // Country
   "US",
   // Subregion
@@ -101,14 +101,14 @@ export const Location = z.enum([
   "WV",
   "WY",
 ]);
-export type Location = z.infer<typeof Location>;
+export type EgridLocation = z.infer<typeof EgridLocation>;
 
 /**
  * Key fields that uniquely identify an eGRID record
  */
 export const EgridRecordKey = z.object({
   year: z.number().int().min(2000).max(2100), // years: 2000 - 2100
-  location: Location,
+  location: EgridLocation,
 });
 
 /**

--- a/src/services/avert-store.ts
+++ b/src/services/avert-store.ts
@@ -1,6 +1,6 @@
 import { AvertRecord } from "@/schema/avert";
 import { AvertModel } from "@/database/avert-model";
-import { Location, PowerPlantClass } from "@/schema/egrid";
+import { EgridLocation, PowerPlantClass } from "@/schema/egrid";
 import { Error as CustomError } from "@/schema/error";
 import { z } from "zod";
 
@@ -45,7 +45,7 @@ export async function addAvertRecord(record: AvertRecord): Promise<void | Custom
 
 export async function getAvertRecordByKey(
   year: number,
-  location: Location,
+  location: EgridLocation,
   powerPlantClass: PowerPlantClass,
 ): Promise<AvertRecord | CustomError> {
   try {

--- a/src/services/avert-store.ts
+++ b/src/services/avert-store.ts
@@ -1,6 +1,6 @@
-import { AvertRecord } from "@/schema/avert";
+import { AvertRecord, AvertLocation } from "@/schema/avert";
 import { AvertModel } from "@/database/avert-model";
-import { EgridLocation, PowerPlantClass } from "@/schema/egrid";
+import { PowerPlantClass } from "@/schema/egrid";
 import { AppError, transformError } from "@/utils/errors";
 import { AppErrorCode } from "@/schema/error";
 
@@ -32,7 +32,7 @@ export async function addAvertRecord(record: AvertRecord): Promise<void> {
 
 export async function getAvertRecordByKey(
   year: number,
-  location: EgridLocation,
+  location: AvertLocation,
   powerPlantClass: PowerPlantClass,
 ): Promise<AvertRecord> {
   try {

--- a/src/services/egrid-store.ts
+++ b/src/services/egrid-store.ts
@@ -1,6 +1,6 @@
 // src/services/egrid-service.ts
 import { z } from "zod";
-import { EgridRecord, Location } from "@/schema/egrid";
+import { EgridRecord, EgridLocation } from "@/schema/egrid";
 import { EgridModel } from "@/database/egrid-model";
 import { Error } from "@/schema/error";
 
@@ -57,7 +57,10 @@ export async function addEgridRecord(egridRecord: EgridRecord): Promise<void | E
  * @returns The matching eGRID record
  * @returns Error if record not found or database operation fails
  */
-export async function getEgridRecordByYearAndLocation(year: number, location: Location): Promise<EgridRecord | Error> {
+export async function getEgridRecordByYearAndLocation(
+  year: number,
+  location: EgridLocation,
+): Promise<EgridRecord | Error> {
   try {
     // Validate input parameters
     const validYear = EgridRecord.shape.year.parse(year);
@@ -104,7 +107,7 @@ export async function getEgridRecordByYearAndLocation(year: number, location: Lo
  * @returns True if the record exists, false otherwise
  * @returns Error if record not found or database operation fails
  */
-export async function doesRecordExist(year: number, location: Location): Promise<boolean | Error> {
+export async function doesRecordExist(year: number, location: EgridLocation): Promise<boolean | Error> {
   try {
     const result = await EgridModel.exists({
       year,

--- a/src/services/egrid-store.ts
+++ b/src/services/egrid-store.ts
@@ -44,10 +44,7 @@ export async function addEgridRecord(egridRecord: EgridRecord): Promise<void> {
  * @returns The matching eGRID record
  * @returns Error if record not found or database operation fails
  */
-export async function getEgridRecordByYearAndLocation(
-  year: number,
-  location: EgridLocation,
-): Promise<EgridRecord> {
+export async function getEgridRecordByYearAndLocation(year: number, location: EgridLocation): Promise<EgridRecord> {
   try {
     // Validate input parameters
     const validYear = EgridRecord.shape.year.parse(year);

--- a/test/database/avert-model.test.ts
+++ b/test/database/avert-model.test.ts
@@ -1,11 +1,11 @@
-import { Location, PowerPlantClass } from "@/schema/egrid";
+import { EgridLocation, PowerPlantClass } from "@/schema/egrid";
 import { AvertModel } from "@/database/avert-model";
 
 describe("AvertModel schema validation", () => {
   it("should validate a correct avert document", () => {
     const avert = new AvertModel({
       year: 2024,
-      location: Location.options[0], // Using a valid location
+      location: EgridLocation.options[0], // Using a valid location
       powerPlantClass: PowerPlantClass.options[0], // Using a valid power plant class
       avoidedCo2EmissionRateLbMwh: 100.5,
       avoidedNoxEmissionRateLbMwh: 10.2,
@@ -28,7 +28,7 @@ describe("AvertModel schema validation", () => {
   it("should fail validation for an invalid powerPlantClass", () => {
     const avert = new AvertModel({
       year: 2024,
-      location: Location.options[0], // Valid location
+      location: EgridLocation.options[0], // Valid location
       powerPlantClass: "InvalidClass", // Not in enum
     });
 

--- a/test/database/avert-model.test.ts
+++ b/test/database/avert-model.test.ts
@@ -6,7 +6,7 @@ describe("AvertModel schema validation", () => {
   it("should validate a correct avert document", () => {
     const avert = new AvertModel({
       year: 2024,
-      location: AvertLocation.options[0], // Using a valid location
+      location: AvertLocation.options[2], // Using a valid location
       powerPlantClass: PowerPlantClass.options[0], // Using a valid power plant class
       avoidedCo2EmissionRateLbMwh: 100.5,
       avoidedNoxEmissionRateLbMwh: 10.2,
@@ -29,7 +29,7 @@ describe("AvertModel schema validation", () => {
   it("should fail validation for an invalid powerPlantClass", () => {
     const avert = new AvertModel({
       year: 2024,
-      location: AvertLocation.options[0], // Valid location
+      location: AvertLocation.options[2], // Valid location
       powerPlantClass: "InvalidClass", // Not in enum
     });
 

--- a/test/database/avert-model.test.ts
+++ b/test/database/avert-model.test.ts
@@ -1,11 +1,12 @@
-import { EgridLocation, PowerPlantClass } from "@/schema/egrid";
+import { PowerPlantClass } from "@/schema/egrid";
 import { AvertModel } from "@/database/avert-model";
+import { AvertLocation } from "@/schema/avert";
 
 describe("AvertModel schema validation", () => {
   it("should validate a correct avert document", () => {
     const avert = new AvertModel({
       year: 2024,
-      location: EgridLocation.options[0], // Using a valid location
+      location: AvertLocation.options[0], // Using a valid location
       powerPlantClass: PowerPlantClass.options[0], // Using a valid power plant class
       avoidedCo2EmissionRateLbMwh: 100.5,
       avoidedNoxEmissionRateLbMwh: 10.2,
@@ -28,7 +29,7 @@ describe("AvertModel schema validation", () => {
   it("should fail validation for an invalid powerPlantClass", () => {
     const avert = new AvertModel({
       year: 2024,
-      location: EgridLocation.options[0], // Valid location
+      location: AvertLocation.options[0], // Valid location
       powerPlantClass: "InvalidClass", // Not in enum
     });
 

--- a/test/database/egrid-model.test.ts
+++ b/test/database/egrid-model.test.ts
@@ -5,7 +5,7 @@ describe("EgridModel schema validation", () => {
   it("should validate a correct egrid document", () => {
     const egrid = new EgridModel({
       year: 2024,
-      location: EgridLocation.options[0], // Using a valid location
+      location: EgridLocation.options[2], // Using a valid location
       nameplateCapacityMw: 100.5,
       annualHeatInputMmbtu: 10.2,
       ozoneSeasonHeatInputMmbtu: 5.1,

--- a/test/database/egrid-model.test.ts
+++ b/test/database/egrid-model.test.ts
@@ -1,11 +1,11 @@
 import { EgridModel } from "@/database/egrid-model";
-import { Location } from "@/schema/egrid";
+import { EgridLocation } from "@/schema/egrid";
 
 describe("EgridModel schema validation", () => {
   it("should validate a correct egrid document", () => {
     const egrid = new EgridModel({
       year: 2024,
-      location: Location.options[0], // Using a valid location
+      location: EgridLocation.options[0], // Using a valid location
       nameplateCapacityMw: 100.5,
       annualHeatInputMmbtu: 10.2,
       ozoneSeasonHeatInputMmbtu: 5.1,

--- a/test/schema/avert.test.ts
+++ b/test/schema/avert.test.ts
@@ -1,21 +1,49 @@
 import { AvertRecord } from "@/schema/avert";
 
 describe("AvertRecord schema", () => {
-  it("should validate correct avert records", () => {
-    const validRecord = {
-      year: 2022,
-      location: "US",
-      powerPlantClass: "OnshoreWind",
-      avoidedCo2EmissionRateLbMwh: 100,
-      avoidedNoxEmissionRateLbMwh: 50,
-      avoidedSo2EmissionRateLbMwh: 20,
-      avoidedPm2_5EmissionRateLbMwh: 10,
-      avoidedVocEmissionRateLbMwh: 5,
-      avoidedNh3EmissionRateLbMwh: 3,
-      capacityFactorPercent: 80,
-    };
+  it("should validate correct avert records across multiple locations", () => {
+    const validRecords = [
+      {
+        year: 2022,
+        location: "US",
+        powerPlantClass: "OnshoreWind",
+        avoidedCo2EmissionRateLbMwh: 100,
+        avoidedNoxEmissionRateLbMwh: 50,
+        avoidedSo2EmissionRateLbMwh: 20,
+        avoidedPm2_5EmissionRateLbMwh: 10,
+        avoidedVocEmissionRateLbMwh: 5,
+        avoidedNh3EmissionRateLbMwh: 3,
+        capacityFactorPercent: 80,
+      },
+      {
+        year: 2022,
+        location: "California",
+        powerPlantClass: "OnshoreWind",
+        avoidedCo2EmissionRateLbMwh: 100,
+        avoidedNoxEmissionRateLbMwh: 50,
+        avoidedSo2EmissionRateLbMwh: 20,
+        avoidedPm2_5EmissionRateLbMwh: 10,
+        avoidedVocEmissionRateLbMwh: 5,
+        avoidedNh3EmissionRateLbMwh: 3,
+        capacityFactorPercent: 80,
+      },
+      {
+        year: 2022,
+        location: "Mid-Atlantic",
+        powerPlantClass: "OnshoreWind",
+        avoidedCo2EmissionRateLbMwh: 100,
+        avoidedNoxEmissionRateLbMwh: 50,
+        avoidedSo2EmissionRateLbMwh: 20,
+        avoidedPm2_5EmissionRateLbMwh: 10,
+        avoidedVocEmissionRateLbMwh: 5,
+        avoidedNh3EmissionRateLbMwh: 3,
+        capacityFactorPercent: 80,
+      },
+    ];
 
-    expect(AvertRecord.parse(validRecord)).toEqual(validRecord);
+    validRecords.forEach((validRecord) => {
+      expect(AvertRecord.parse(validRecord)).toEqual(validRecord);
+    });
   });
 
   it("should invalidate incorrect avert records", () => {
@@ -60,5 +88,23 @@ describe("AvertRecord schema", () => {
     invalidRecords.forEach((invalidRecord) => {
       expect(() => AvertRecord.parse(invalidRecord)).toThrow();
     });
+  });
+
+  it("should be exact match", () => {
+    const invalidRecord = {
+      //mid-atlantic should fail
+      year: 2022,
+      location: "mid-atlantic",
+      powerPlantClass: "OnshoreWind",
+      avoidedCo2EmissionRateLbMwh: 100,
+      avoidedNoxEmissionRateLbMwh: 50,
+      avoidedSo2EmissionRateLbMwh: 20,
+      avoidedPm2_5EmissionRateLbMwh: 10,
+      avoidedVocEmissionRateLbMwh: 5,
+      avoidedNh3EmissionRateLbMwh: 3,
+      capacityFactorPercent: 80,
+    };
+
+    expect(() => AvertRecord.parse(invalidRecord)).toThrow();
   });
 });

--- a/test/schema/egrid.test.ts
+++ b/test/schema/egrid.test.ts
@@ -1,4 +1,4 @@
-import { EgridRecord, EgridRecordData, EgridRecordKey, Location, PowerPlantClass } from "@/schema/egrid";
+import { EgridRecord, EgridRecordData, EgridRecordKey, EgridLocation, PowerPlantClass } from "@/schema/egrid";
 
 describe("PowerPlantClass schema", () => {
   it("should validate correct power plant classes", () => {
@@ -21,7 +21,7 @@ describe("Location schema", () => {
     const validLocations = ["US", "AKGD", "PRMS", "SRVC", "AK", "CA", "CO", "CT", "MA", "OH", "WY"];
 
     validLocations.forEach((validLocation) => {
-      expect(Location.parse(validLocation)).toBe(validLocation);
+      expect(EgridLocation.parse(validLocation)).toBe(validLocation);
     });
   });
 
@@ -29,7 +29,7 @@ describe("Location schema", () => {
     const invalidLocations = ["EU", "Asia", "Africa"];
 
     invalidLocations.forEach((invalidLocation) => {
-      expect(() => Location.parse(invalidLocation)).toThrow();
+      expect(() => EgridLocation.parse(invalidLocation)).toThrow();
     });
   });
 });


### PR DESCRIPTION
## Developer: Isha Varrier 

Closes #69

### Pull Request Summary

Changed Location enum to be EgridLocation. Updated references of Location in other files. 
Added AvertLocation enum. Updated reference for AvertRecord.
Added unit tests for AvertLocation. 

### Modifications
Mainly just updated reference for new enums: 

src/components/ui/calculator-form.tsx
src/database/avert-model.ts
src/database/egrid-model.ts
src/schema/api.ts
src/schema/avert.ts
src/schema/egrid.ts
src/services/avert-store.ts
src/services/egrid-store.ts
test/database/avert-model.test.ts
test/database/egrid-model.test.ts
test/schema/avert.test.ts
test/schema/egrid.test.ts

### Testing Considerations

Tested spelling differences, valid and invalid record data. 

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

{put screenshots of your change, or even better a screencast displaying the functionality}
