### PR TITLE
90 fetch egrid avert

### DIFF
--- a/src/app/api/calculate/route.ts
+++ b/src/app/api/calculate/route.ts
@@ -2,16 +2,33 @@ import { FormulaParser } from "@/utils/formula-parser";
 import { apiErrorHandler } from "@/utils/errors";
 import { CalculateInput } from "@/schema/api";
 import { NextRequest, NextResponse } from "next/server";
+import { getEgridRecordByKey } from "@/services/egrid-store";
+import { getAvertRecordByKey } from "@/services/avert-store";
+import { EgridRecordData } from "@/schema/egrid";
+import { AvertRecordData } from "@/schema/avert";
 
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
     const inputData = CalculateInput.parse(body);
 
-    const { location, powerPlantClass, ...inputVariables } = inputData;
-    console.log("location: " + location);
+    const { yearOfStudy, egridLocation, avertLocation, powerPlantClass, ...inputVariables } = inputData;
+    console.log("year: " + yearOfStudy);
+    console.log("egrid location: " + egridLocation);
+    console.log("avert location: " + avertLocation);
     console.log("power plant class: " + powerPlantClass);
-    const formulaParser = new FormulaParser(inputVariables);
+
+    const egridRecord = getEgridRecordByKey(yearOfStudy, egridLocation);
+    const avertRecord = getAvertRecordByKey(yearOfStudy, avertLocation, powerPlantClass);
+
+    const egridRecordData = EgridRecordData.parse(egridRecord);
+    const avertRecordData = AvertRecordData.parse(avertRecord);
+
+    const formulaParser = new FormulaParser({
+      ...inputVariables,
+      ...egridRecordData,
+      ...avertRecordData,
+    });
     const result = formulaParser.evaluate();
 
     return NextResponse.json(result);

--- a/src/app/api/calculate/route.ts
+++ b/src/app/api/calculate/route.ts
@@ -7,6 +7,13 @@ import { getAvertRecordByKey } from "@/services/avert-store";
 import { EgridRecordData } from "@/schema/egrid";
 import { AvertRecordData } from "@/schema/avert";
 
+function extractNumericFields(obj: Record<string, unknown>): Record<string, number> {
+  return Object.fromEntries(Object.entries(obj).filter(([, value]) => typeof value === "number")) as Record<
+    string,
+    number
+  >;
+}
+
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
@@ -21,8 +28,8 @@ export async function POST(req: NextRequest) {
     const egridRecord = getEgridRecordByKey(yearOfStudy, egridLocation);
     const avertRecord = getAvertRecordByKey(yearOfStudy, avertLocation, powerPlantClass);
 
-    const egridRecordData = EgridRecordData.parse(egridRecord);
-    const avertRecordData = AvertRecordData.parse(avertRecord);
+    const egridRecordData = extractNumericFields(EgridRecordData.parse(egridRecord));
+    const avertRecordData = extractNumericFields(AvertRecordData.parse(avertRecord));
 
     const formulaParser = new FormulaParser({
       ...inputVariables,

--- a/src/components/calculator-form.tsx
+++ b/src/components/calculator-form.tsx
@@ -9,9 +9,11 @@ import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@
 import { Button } from "@/components/ui/button";
 import { CalculateInput } from "@/schema/api";
 import { EgridLocation, PowerPlantClass } from "@/schema/egrid";
+import { AvertLocation } from "@/schema/avert";
 
 const powerPlantOptions = PowerPlantClass.options;
-const locationOptions = EgridLocation.options;
+const egridLocationOptions = EgridLocation.options;
+const avertLocationOptions = AvertLocation.options;
 
 export default function CalculatorForm() {
   const form = useForm({
@@ -70,16 +72,39 @@ export default function CalculatorForm() {
 
         <FormField
           control={form.control}
-          name="location"
+          name="egridLocation"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>Location</FormLabel>
+              <FormLabel>Egrid Location</FormLabel>
               <Select onValueChange={field.onChange} defaultValue={field.value}>
                 <SelectTrigger className="text-gray-300">
-                  <SelectValue placeholder="Select Location" />
+                  <SelectValue placeholder="Select Egrid Location" />
                 </SelectTrigger>
                 <SelectContent>
-                  {locationOptions.map((option) => (
+                  {egridLocationOptions.map((option) => (
+                    <SelectItem key={option} value={option}>
+                      {option}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="avertLocation"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Avert Location</FormLabel>
+              <Select onValueChange={field.onChange} defaultValue={field.value}>
+                <SelectTrigger className="text-gray-300">
+                  <SelectValue placeholder="Select Avert Location" />
+                </SelectTrigger>
+                <SelectContent>
+                  {avertLocationOptions.map((option) => (
                     <SelectItem key={option} value={option}>
                       {option}
                     </SelectItem>

--- a/src/schema/api.ts
+++ b/src/schema/api.ts
@@ -1,10 +1,12 @@
 import { z } from "zod";
 import { PowerPlantClass, EgridLocation } from "@/schema/egrid";
+import { AvertLocation } from "@/schema/avert";
 
 export const CalculateInput = z.object({
   installedCapacity: z.number().min(0, { message: "Installed capacity must be at least 0" }),
   powerPlantClass: PowerPlantClass,
-  location: EgridLocation,
+  egridLocation: EgridLocation,
+  avertLocation: AvertLocation,
   capacityFactor: z
     .number()
     .min(0, { message: "Capacity factor must be at least 0" })

--- a/test/schema/api.test.ts
+++ b/test/schema/api.test.ts
@@ -5,7 +5,8 @@ describe("CalculateInput schema", () => {
     const validInput = {
       installedCapacity: 100,
       powerPlantClass: "OnshoreWind",
-      location: "US",
+      egridLocation: "US",
+      avertLocation: "California",
       capacityFactor: 0.25,
       population2070: 1000000,
       startYear: 2020,
@@ -20,7 +21,8 @@ describe("CalculateInput schema", () => {
     const invalidInput = {
       installedCapacity: "100", // should be a number
       powerPlantClass: "OnshoreWind",
-      location: "US",
+      egridlocation: "US",
+      avertLocation: "California",
       capacityFactor: 0.25,
       population2070: 1000000,
       startYear: 2020,
@@ -35,7 +37,8 @@ describe("CalculateInput schema", () => {
     const invalidInput = {
       installedCapacity: 100,
       powerPlantClass: "OnshoreWind",
-      location: "US",
+      egridLocation: "US",
+      avertLocation: "California",
       capacityFactor: 0.25,
       population2070: 1000000,
       startYear: 2020,


### PR DESCRIPTION
## Developer: Shayan Daijavad

Closes #90 

### Pull Request Summary

Changed the calculate route to fetch egrid and avert records and pass them into the FormulaParser before evaluation.

### Modifications

src/components/calculator-form.tsx
src/schema/api.ts
test/schema/api.test.ts
Changed the above 3 files to separate the calculator location input into an EgridLocation and an AvertLocation. 

The alternative is to somehow convert EgridLocations into AvertLocations, or to abstract both into a type that can be used to determine both Egrid and Avert. It may be worth considering just taking in a state from the user and determining EgridLocation and AvertLocation on our end for a smooth user experience, but I'm not sure how important the subregions in the EgridLocation type are. 

src/app/api/calculate/route.ts
Fetched Egrid and Avert records in the calculate route and passed them into the FormulaParser.

### Testing Considerations
None

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

