### PR TITLE
Ignore unsupported egrid records in data fetcher

### DIFF
--- a/src/services/egrid-fetch.ts
+++ b/src/services/egrid-fetch.ts
@@ -487,12 +487,18 @@ const transformCountryData = (countrySheet: XLSX.WorkSheet): EgridRecord => {
 const transformSubregionData = (subregionSheet: XLSX.WorkSheet): EgridRecord[] => {
   const subregionData = XLSX.utils.sheet_to_json(subregionSheet);
   if (subregionData.length > 1) {
-    return subregionData.slice(1).map((raw: unknown) => {
-      const decodedRaw = trimColumnNames(z.record(z.unknown()).parse(raw));
-      const location = sanitizeStringValue(decodedRaw[SUBREGION_LOCATION_FIELD]);
-      const decodedLocation = EgridLocation.parse(location);
-      return transformRawData(decodedRaw, YEAR, decodedLocation, SUBREGION_PREFIX);
-    });
+    return subregionData
+      .slice(1)
+      .map((raw: unknown) => {
+        const decodedRaw = trimColumnNames(z.record(z.unknown()).parse(raw));
+        const location = sanitizeStringValue(decodedRaw[SUBREGION_LOCATION_FIELD]);
+        const { data: decodedLocation } = EgridLocation.safeParse(location);
+        if (!decodedLocation) {
+          return null;
+        }
+        return transformRawData(decodedRaw, YEAR, decodedLocation, SUBREGION_PREFIX);
+      })
+      .filter((record) => record !== null);
   }
   throw new AppError(AppErrorCode.enum.SERVICE_ERROR, "Unable to find subregion data in eGRID file");
 };
@@ -500,12 +506,18 @@ const transformSubregionData = (subregionSheet: XLSX.WorkSheet): EgridRecord[] =
 const transformStateData = (stateSheet: XLSX.WorkSheet): EgridRecord[] => {
   const stateData = XLSX.utils.sheet_to_json(stateSheet);
   if (stateData.length > 1) {
-    return stateData.slice(1).map((raw: unknown) => {
-      const decodedRaw = trimColumnNames(z.record(z.unknown()).parse(raw));
-      const location = sanitizeStringValue(decodedRaw[STATE_LOCATION_FIELD]);
-      const decodedLocation = EgridLocation.parse(location);
-      return transformRawData(decodedRaw, YEAR, decodedLocation, STATE_PREFIX);
-    });
+    return stateData
+      .slice(1)
+      .map((raw: unknown) => {
+        const decodedRaw = trimColumnNames(z.record(z.unknown()).parse(raw));
+        const location = sanitizeStringValue(decodedRaw[STATE_LOCATION_FIELD]);
+        const { data: decodedLocation } = EgridLocation.safeParse(location);
+        if (!decodedLocation) {
+          return null;
+        }
+        return transformRawData(decodedRaw, YEAR, decodedLocation, STATE_PREFIX);
+      })
+      .filter((record) => record !== null);
   }
   throw new AppError(AppErrorCode.enum.SERVICE_ERROR, "Unable to find state data in eGRID file");
 };

--- a/test/mocks/egrid-mocks.ts
+++ b/test/mocks/egrid-mocks.ts
@@ -838,7 +838,6 @@ export const MOCK_EGRID_SUBREGION_SHEET = [
     "eGRID subregion nonbaseload other fossil generation percent (resource mix)": 0,
     "eGRID subregion nonbaseload other unknown/ purchased fuel generation percent (resource mix)": 0,
   },
-  /* Not in usable eGRID locations
   {
     "Data Year": 2022,
     "eGRID subregion acronym": "AKMS",
@@ -1005,7 +1004,6 @@ export const MOCK_EGRID_SUBREGION_SHEET = [
     "eGRID subregion nonbaseload other fossil generation percent (resource mix)": 0,
     "eGRID subregion nonbaseload other unknown/ purchased fuel generation percent (resource mix)": 0,
   },
-  */
 ];
 
 export const MOCK_EGRID_STATE_SHEET = [
@@ -1175,7 +1173,6 @@ export const MOCK_EGRID_STATE_SHEET = [
     "State nonbaseload other fossil generation percent (resource mix)": "STNBOFPR",
     "State nonbaseload other unknown/ purchased fuel generation percent (resource mix)": "STNBOPPR",
   },
-  /* Not in usable eGRID locations
   {
     "Data Year": 2022,
     "State abbreviation": "AK",
@@ -1342,7 +1339,6 @@ export const MOCK_EGRID_STATE_SHEET = [
     "State nonbaseload other fossil generation percent (resource mix)": 0,
     "State nonbaseload other unknown/ purchased fuel generation percent (resource mix)": 0,
   },
-  */
   {
     "Data Year": 2022,
     "State abbreviation": "AL",

--- a/test/services/egrid-fetch.test.ts
+++ b/test/services/egrid-fetch.test.ts
@@ -39,6 +39,7 @@ describe("eGRID data fetcher", () => {
   it("should fetch and parse eGRID data", async () => {
     const result = await fetchAndTransformEgridData();
 
+    // 6 total records, but we are ignoring 1 invalid subregion and 1 invalid state
     expect(result.length).toEqual(4);
     expect(result[0]).toEqual(MOCK_EGRID_RECORD);
     expect(mockedAxios.get).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Developer: Ryan Hu

Closes N/A

### Pull Request Summary

Egrid data fetcher was throwing a validation error when trying to decode unsupported subregion/state records (e.g. Alaska). We can filter unsupported locations before decoding to prevent this.

### Modifications

Egrid data fetcher and egrid mocks

### Testing Considerations

Verified unit tests pass and route works

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Git-Commits-Pull-Requests-1-fd22949218fd4b4c976146a0d741b9bf)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

