### PR TITLE
Add cron authorization

### DIFF
--- a/src/app/api/avert/route.ts
+++ b/src/app/api/avert/route.ts
@@ -1,12 +1,12 @@
 import { fetchAndTransformAvertData } from "@/services/avert-fetch";
 import { addAvertRecord } from "@/services/avert-store";
 import { apiErrorHandler } from "@/utils/errors";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
-export async function GET(request: Request) {
-  const authHeader = request.headers.get("Authorization");
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
 
-  if (authHeader !== process.env.CRON_SECRET) {
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 

--- a/src/app/api/avert/route.ts
+++ b/src/app/api/avert/route.ts
@@ -3,7 +3,13 @@ import { addAvertRecord } from "@/services/avert-store";
 import { apiErrorHandler } from "@/utils/errors";
 import { NextResponse } from "next/server";
 
-export async function GET() {
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("Authorization");
+
+  if (authHeader !== process.env.CRON_SECRET) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
   try {
     const records = await fetchAndTransformAvertData();
     //iterate over the AvertRecord objects and add them to the database

--- a/src/app/api/egrid/route.ts
+++ b/src/app/api/egrid/route.ts
@@ -5,9 +5,14 @@ import { NextResponse } from "next/server";
 
 /**
  * Route to fetch the egrid data
- * TODO: Add authorization to restrict access to scheduled cron job
  */
-export const GET = async () => {
+export async function GET(request: Request) {
+  const authHeader = request.headers.get("authorization");
+
+  if (authHeader !== process.env.CRON_SECRET) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
   try {
     const records = await fetchAndTransformEgridData();
     await Promise.all(records.map(addEgridRecord));
@@ -15,4 +20,4 @@ export const GET = async () => {
   } catch (error) {
     return apiErrorHandler(error);
   }
-};
+}

--- a/src/app/api/egrid/route.ts
+++ b/src/app/api/egrid/route.ts
@@ -1,15 +1,15 @@
 import { fetchAndTransformEgridData } from "@/services/egrid-fetch";
 import { addEgridRecord } from "@/services/egrid-store";
 import { apiErrorHandler } from "@/utils/errors";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * Route to fetch the egrid data
  */
-export async function GET(request: Request) {
+export async function GET(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
 
-  if (authHeader !== process.env.CRON_SECRET) {
+  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 

--- a/test/app/api/egrid.test.ts
+++ b/test/app/api/egrid.test.ts
@@ -1,6 +1,9 @@
 import { GET } from "@/app/api/egrid/route";
 import { fetchAndTransformEgridData } from "@/services/egrid-fetch";
 import { addEgridRecord } from "@/services/egrid-store";
+import { NextRequest } from "next/server";
+
+process.env.CRON_SECRET = "test-secret";
 
 jest.mock("@/services/egrid-fetch", () => ({
   fetchAndTransformEgridData: jest.fn(),
@@ -9,6 +12,12 @@ jest.mock("@/services/egrid-fetch", () => ({
 jest.mock("@/services/egrid-store", () => ({
   addEgridRecord: jest.fn(),
 }));
+
+const TEST_REQUEST = {
+  headers: new Headers({
+    authorization: `Bearer ${process.env.CRON_SECRET}`,
+  }),
+} as unknown as NextRequest;
 
 describe("/api/egrid route", () => {
   beforeEach(() => {
@@ -20,7 +29,7 @@ describe("/api/egrid route", () => {
     (fetchAndTransformEgridData as jest.Mock).mockResolvedValue(mockRecords);
     (addEgridRecord as jest.Mock).mockResolvedValue(undefined);
 
-    const response = await GET();
+    const response = await GET(TEST_REQUEST);
 
     expect(fetchAndTransformEgridData).toHaveBeenCalled();
     expect(addEgridRecord).toHaveBeenCalledTimes(mockRecords.length);
@@ -34,7 +43,7 @@ describe("/api/egrid route", () => {
     const testError = new Error("fetch error");
     (fetchAndTransformEgridData as jest.Mock).mockRejectedValue(testError);
 
-    const response = await GET();
+    const response = await GET(TEST_REQUEST);
 
     expect(response.status).toEqual(500);
   });
@@ -45,9 +54,19 @@ describe("/api/egrid route", () => {
     const testError = new Error("store error");
     (addEgridRecord as jest.Mock).mockRejectedValue(testError);
 
-    const response = await GET();
+    const response = await GET(TEST_REQUEST);
 
     expect(addEgridRecord).toHaveBeenCalled();
     expect(response.status).toEqual(500);
+  });
+
+  test("returns unauthorized when no auth header is provided", async () => {
+    const requestWithoutAuth = {
+      headers: new Headers(),
+    } as unknown as NextRequest;
+
+    const response = await GET(requestWithoutAuth);
+
+    expect(response.status).toEqual(401);
   });
 });


### PR DESCRIPTION
## Developer: Misha Bandi

Closes #103 

### Pull Request Summary

Added authorization logic to /api/avert and /api/egrid so that only Vercel cron jobs can access them. This prevents unauthorized requests and improves security.

### Modifications

src/app/api/avert/route.ts:  
  - Checked Authorization header against process.env.CRON_SECRET
  - Returned 401 Unauthorized if it didn’t match
src/app/api/egrid/route.ts:  
  - Same logic added for secure cron only access

### Testing Considerations

- Verified both routes return 401 Unauthorized when the header is missing/incorrect
- Verified correct Authorization allows the request
- Successfully triggered /api/avert and saw database logic run

**Note: /api/egrid currently gives a validation error because 'AKGD' isn’t in the list of allowed regions. We may need to check if it should be added or skipped.

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Git-Commits-Pull-Requests-1-fd22949218fd4b4c976146a0d741b9bf)
- [x] The developer name is specified
- [x] The summary is completed
- [ ] Assign reviewers