### PR TITLE
fix: null result values causing frontend decode error

### DIFF
--- a/src/schema/api.ts
+++ b/src/schema/api.ts
@@ -24,6 +24,6 @@ export const CalculateInput = z.object({
 
 export type CalculateInput = z.infer<typeof CalculateInput>;
 
-export const CalculateResult = z.record(FormulaId, z.number());
+export const CalculateResult = z.record(FormulaId, z.union([z.number(), z.null()]));
 
 export type CalculateResult = z.infer<typeof CalculateResult>;


### PR DESCRIPTION
## Developer: Ryan Hu

Closes N/A

### Pull Request Summary

The `averageOnshoreWindTurbinesInCalifornia` and `averageOffshoreWindTurbinesInCalifornia` formulas depend on the eGRID`annualWindNetGenerationMwh` field. Sometimes this field is 0 (for states like AL and AR), which creates a divide by zero error. The formula parser handles this by returning null, but our `CalculateResult` decode crashes when it sees a null.

### Modifications

Changed `CalculateResult` to allow null values

### Testing Considerations

Tested with AR and AL states

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit messages follows our [guidelines](https://h4i.notion.site/Git-Commits-Pull-Requests-1-fd22949218fd4b4c976146a0d741b9bf)
- [x] The developer name is specified
- [x] The summary is completed
- [x] Assign reviewers

### Screenshots/Screencast

